### PR TITLE
base64url: fix "+" match

### DIFF
--- a/src/gmail_clj/core.clj
+++ b/src/gmail_clj/core.clj
@@ -135,7 +135,7 @@
 (defn str->b64 [input]
   (let [input (if (bytes? input) input (.getBytes input))]
     (-> (String. (b64/encode input) "UTF-8")
-        (clojure.string/replace "\\+" "-")
+        (clojure.string/replace "+" "-")
         (clojure.string/replace "/" "_"))))
 
 (defn b64->str [input]


### PR DESCRIPTION
The original match argument was "\+", which would be correct if the
match was a regex pattern (because we want to replace the "+"
character), but we're dealing with simple string substitution, so match
should just be "+".
